### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/gen_pack.yml
+++ b/.github/workflows/gen_pack.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pack:
     name: Generate pack
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/gen_pack.yml
+++ b/.github/workflows/gen_pack.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - main
   release:
     types: [published]
 
@@ -16,7 +18,7 @@ jobs:
     name: Generate pack
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/gen_pack.sh
+++ b/gen_pack.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.9.1"
+REQUIRED_GEN_PACK_LIB="0.11.1"
 
 # Set default command line arguments
 DEFAULT_ARGS=()


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.